### PR TITLE
Check for use of AuxOrigin

### DIFF
--- a/plot_gerbers.py
+++ b/plot_gerbers.py
@@ -57,7 +57,7 @@ popt.SetAutoScale(False)
 popt.SetScale(1)
 popt.SetMirror(False)
 popt.SetUseGerberAttributes(False)
-popt.SetExcludeEdgeLayer(True);
+popt.SetExcludeEdgeLayer(True)
 popt.SetScale(1)
 popt.SetUseAuxOrigin(True)
 popt.SetNegative(False)
@@ -127,8 +127,12 @@ drlwriter.SetMapFileFormat( PLOT_FORMAT_PDF )
 
 mirror = False
 minimalHeader = False
-#offset = wxPoint(0,0)
-offset = board.GetAuxOrigin()
+
+if popt.GetUseAuxOrigin():
+    offset = board.GetAuxOrigin()
+else:
+    offset = wxPoint(0,0)
+
 mergeNPTH = True
 drlwriter.SetOptions( mirror, minimalHeader, offset, mergeNPTH )
 


### PR DESCRIPTION
Drill file generation is currently hard-coded with `offset = board.GetAuxOrigin()`. If the user changes to `popt.SetUseAuxOrigin(False)`, the drill file will be incorrectly offset:

![incorrect_drl](https://user-images.githubusercontent.com/7242621/70401216-e2205480-19eb-11ea-9764-0210a54f143f.png)

Adding a check to determine which offset to use fixes this.
