### PR TITLE
add location of inkscape 1.0.2-2 on Windows 10 to pathlist

### DIFF
--- a/plot_board.py
+++ b/plot_board.py
@@ -418,7 +418,9 @@ def render(pcb, plot_plan, output_filename, mirror=False):
 	# Hack your path to add a bunch of plausible locations for inkscape
 	pathlist = [
 		'C:\\Program Files\\Inkscape',
+		'C:\\Program Files\\Inkscape\\bin',
 		'C:\\Program Files (x86)\\Inkscape',
+		'C:\\Program Files (x86)\\Inkscape\\bin',
 		'/usr/local/bin',
 		'/usr/bin/'
 	]


### PR DESCRIPTION
I was getting 
```
C:\Users\User\Desktop\kicadScripts>"C:\Program Files\KiCad\bin\python.exe" plot_board.py D:\project\project.kicad_pcb
Merging layers...
Rasterizing...
[Error 2] The system cannot find the file specified
Merging layers...
Rasterizing...
[Error 2] The system cannot find the file specified
```

because my system environment path was not pointing to the /bin/ folder inside the Windows 10 Inkscape directory. After adding /bin/ directory to the pathlist in the code it was able to run correctly.  Would be good to include if some people do not have the path set at all or like me, to the wrong directory.
```
C:\Users\User\Desktop\kicadScripts>"C:\Program Files\KiCad\bin\python.exe" plot_board.py D:\project\project.kicad_pcb
Merging layers...
Rasterizing...
Detected Inkscape version 1.0+
Merging layers...
Rasterizing...
Detected Inkscape version 1.0+
```